### PR TITLE
WIP: Fixes 0.3.1

### DIFF
--- a/databricks_sync/sdk/generators/cluster_policies.py
+++ b/databricks_sync/sdk/generators/cluster_policies.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from pathlib import Path
 from typing import Generator, Dict, Any, Tuple
@@ -85,10 +86,15 @@ class ClusterPolicyHCLGenerator(APIGenerator):
         return data.get('name', None)
 
     @staticmethod
+    def __encode_definition(definition: str):
+        encoded_data = base64.b64encode(definition.encode("utf-8")).decode("utf-8")
+        return f'${{base64decode("{encoded_data}")}}'
+
+    @staticmethod
     def __make_cluster_policy_dict(data: Dict[str, Any]) -> Dict[str, Any]:
         return TerraformDictBuilder(ResourceCatalog.CLUSTER_POLICY_RESOURCE,
                                     data, object_id=ClusterPolicyHCLGenerator.__get_cluster_policy_raw_id,
                                     object_name=ClusterPolicyHCLGenerator.__get_cluster_policy_name). \
-            add_required("definition", lambda: data["definition"]). \
+            add_required("definition", lambda: ClusterPolicyHCLGenerator.__encode_definition(data["definition"])). \
             add_required("name", lambda: data["name"]). \
             to_dict()

--- a/databricks_sync/sdk/generators/clusters.py
+++ b/databricks_sync/sdk/generators/clusters.py
@@ -5,12 +5,14 @@ from typing import Generator, Dict, Any, Optional
 from databricks_cli.sdk import ApiClient
 from databricks_cli.sdk import ClusterService, ManagedLibraryService
 
+from databricks_sync import log
 from databricks_sync.sdk.config import export_config
 from databricks_sync.sdk.generators import LocalFilterBy
 from databricks_sync.sdk.generators.permissions import PermissionsHelper, NoDirectPermissionsError
 from databricks_sync.sdk.hcl.json_to_hcl import TerraformDictBuilder, Interpolate
 from databricks_sync.sdk.message import APIData
 from databricks_sync.sdk.pipeline import APIGenerator
+from databricks_sync.sdk.service.global_init_scripts import GlobalInitScriptsService
 from databricks_sync.sdk.sync.constants import ResourceCatalog, CloudConstants, GeneratorCatalog, \
     ForEachBaseIdentifierCatalog
 from databricks_sync.sdk.utils import normalize_identifier, handle_azure_libraries, \
@@ -36,6 +38,7 @@ class ClusterHCLGenerator(APIGenerator):
         self.__custom_map_vars = {**default_custom_map_vars, **(custom_map_vars or {})}
         self.__service = ClusterService(self.api_client)
         self.__lib_service = ManagedLibraryService(self.api_client)
+        self.__global_init_scripts_service = GlobalInitScriptsService(self.api_client)
         self.__perms = PermissionsHelper(self.api_client)
         self.__pin_first_20 = pin_first_20
         self.__max_pin_count = 20
@@ -55,14 +58,14 @@ class ClusterHCLGenerator(APIGenerator):
         )
 
     @staticmethod
-    def _handle_depends_on(tdb: TerraformDictBuilder):
+    def _handle_depends_on(tdb: TerraformDictBuilder, has_global_init_scripts):
         depends_on = []
         # If user configures dbfs files wait for that with regards to init scripts
         if export_config.contains(GeneratorCatalog.DBFS_FILE) is True:
             depends_on.append(Interpolate.depends_on(ResourceCatalog.DBFS_FILE_RESOURCE,
                                                      ForEachBaseIdentifierCatalog.DBFS_FILES_BASE_IDENTIFIER))
         # Wait for all global init scripts to be created before starting clusters
-        if export_config.contains(GeneratorCatalog.GLOBAL_INIT_SCRIPT) is True:
+        if export_config.contains(GeneratorCatalog.GLOBAL_INIT_SCRIPT) is True and has_global_init_scripts is True:
             depends_on.append(Interpolate.depends_on(ResourceCatalog.GLOBAL_INIT_SCRIPTS_RESOURCE,
                                                      ForEachBaseIdentifierCatalog.GLOBAL_INIT_SCRIPTS_BASE_IDENTIFIER))
         if len(depends_on) > 0:
@@ -148,12 +151,25 @@ class ClusterHCLGenerator(APIGenerator):
     def __get_cluster_name(data: Dict[str, Any]) -> Optional[str]:
         return data.get('cluster_name', None)
 
-    @staticmethod
-    def __get_cluster_dict(data: Dict[str, Any]):
-        return ClusterHCLGenerator.make_cluster_dict(data, depends_on=True)
+    def __has_global_init_scripts(self) -> bool:
+        # GIS not configured
+        if export_config.contains(GeneratorCatalog.GLOBAL_INIT_SCRIPT) is False:
+            return False
+        # GIS configured but may be empty
+        resp = self.__global_init_scripts_service.list_global_init_scripts()
+        log.info(f"Fetched all global init scripts")
+        if "scripts" not in resp:
+            return False
+        scripts = resp["scripts"]
+        return len(scripts) > 0
+
+    def __get_cluster_dict(self, data: Dict[str, Any]):
+        return ClusterHCLGenerator.make_cluster_dict(data, depends_on=True,
+                                                     has_global_init_scripts=self.__has_global_init_scripts())
 
     @staticmethod
-    def make_cluster_dict(data: Dict[str, Any], depends_on=False, is_job=False) -> Dict[str, Any]:
+    def make_cluster_dict(data: Dict[str, Any], depends_on=False, is_job=False,
+                          has_global_init_scripts=False) -> Dict[str, Any]:
         id_field = "id"
         tdb = TerraformDictBuilder(ResourceCatalog.CLUSTER_RESOURCE,
                                    data, job_mode=f"{is_job}", object_id=ClusterHCLGenerator.__get_cluster_raw_id,
@@ -200,7 +216,7 @@ class ClusterHCLGenerator(APIGenerator):
             add_dynamic_blocks("cluster_log_conf", lambda: data["azure_cluster_log_conf"], CloudConstants.AZURE). \
             add_dynamic_blocks("cluster_log_conf", lambda: data["cloud_agnostic_cluster_log_conf"])
         if depends_on is True:
-            ClusterHCLGenerator._handle_depends_on(tdb)
+            ClusterHCLGenerator._handle_depends_on(tdb, has_global_init_scripts=has_global_init_scripts)
         if is_job is True:
             tdb.add_optional("node_type_id", lambda: data["node_type_id"])
         else:

--- a/databricks_sync/sdk/generators/jobs.py
+++ b/databricks_sync/sdk/generators/jobs.py
@@ -164,6 +164,10 @@ class JobHCLGenerator(APIGenerator):
             del data["settings"]["notebook_task"]["revision_timestamp"]
             # del azure_job["settings"]["notebook_task"]["revision_timestamp"]
 
+        # artifact from git integration for notebook tasks
+        if "source" in data.get("settings", []).get("notebook_task", []):
+            del data["settings"]["notebook_task"]["source"]
+
         # Existing cluster - there's no need to generate per cloud object
         # New cluster - modify the object, add var.CLOUD and generate an object per cloud
         if "new_cluster" in data.get("settings", []):

--- a/databricks_sync/sdk/generators/notebook.py
+++ b/databricks_sync/sdk/generators/notebook.py
@@ -1,6 +1,6 @@
 import functools
 from base64 import b64decode
-from pathlib import Path
+from pathlib import Path, PosixPath
 from typing import List, Generator, Dict, Any, Union, Optional
 
 from databricks_cli.sdk import WorkspaceService, ApiClient
@@ -54,7 +54,7 @@ class NotebookHCLGenerator(DownloaderAPIGenerator):
         return GeneratorCatalog.NOTEBOOK
 
     def __get_parent_folder(self, path):
-        path = Path(path)
+        path = PosixPath(path)
         return str(path.parent.absolute())
 
     def __process_folder(self, path):
@@ -160,7 +160,7 @@ class NotebookHCLGenerator(DownloaderAPIGenerator):
         path_s: str = data.get("path", None)
         if path_s is None:
             return None
-        path: Path = Path(path_s.lstrip("/"))
+        path: Path = PosixPath(path_s.lstrip("/"))
         if len(path.parents) <= 1:
             return None
         return str(path.parent)
@@ -171,7 +171,7 @@ class NotebookHCLGenerator(DownloaderAPIGenerator):
         path_s: str = data.get("path", None)
         if path_s is None:
             return None
-        path: Path = Path(path_s)
+        path: Path = PosixPath(path_s)
         return normalize_identifier(f"{path.name}_{nbook_id}")
 
     def __make_notebook_dict(self, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -213,7 +213,7 @@ class NotebookHCLGenerator(DownloaderAPIGenerator):
     def __folder_iter(self, notebook_obj):
         notebook_path = notebook_obj["path"]
         folder_path = notebook_path
-        for parent in Path(folder_path).parents:
+        for parent in PosixPath(folder_path).parents:
             if self.__is_processed_folder(parent):
                 continue
             elif str(parent) == "/":

--- a/databricks_sync/sdk/generators/notebook.py
+++ b/databricks_sync/sdk/generators/notebook.py
@@ -53,10 +53,6 @@ class NotebookHCLGenerator(DownloaderAPIGenerator):
     def folder_name(self) -> str:
         return GeneratorCatalog.NOTEBOOK
 
-    def __get_parent_folder(self, path):
-        path = PosixPath(path)
-        return str(path.parent.absolute())
-
     def __process_folder(self, path):
         self.__folder_set[path] = 1
         log.debug(f"Processing folder: {path} due to seeing for the first time")

--- a/databricks_sync/sdk/generators/notebook.py
+++ b/databricks_sync/sdk/generators/notebook.py
@@ -1,6 +1,6 @@
 import functools
 from base64 import b64decode
-from pathlib import Path, PosixPath
+from pathlib import Path, PurePosixPath
 from typing import List, Generator, Dict, Any, Union, Optional
 
 from databricks_cli.sdk import WorkspaceService, ApiClient
@@ -160,7 +160,7 @@ class NotebookHCLGenerator(DownloaderAPIGenerator):
         path_s: str = data.get("path", None)
         if path_s is None:
             return None
-        path: Path = PosixPath(path_s.lstrip("/"))
+        path: PurePosixPath = PurePosixPath(path_s.lstrip("/"))
         if len(path.parents) <= 1:
             return None
         return str(path.parent)
@@ -171,7 +171,7 @@ class NotebookHCLGenerator(DownloaderAPIGenerator):
         path_s: str = data.get("path", None)
         if path_s is None:
             return None
-        path: Path = PosixPath(path_s)
+        path: PurePosixPath = PurePosixPath(path_s)
         return normalize_identifier(f"{path.name}_{nbook_id}")
 
     def __make_notebook_dict(self, data: Dict[str, Any]) -> Dict[str, Any]:
@@ -213,7 +213,7 @@ class NotebookHCLGenerator(DownloaderAPIGenerator):
     def __folder_iter(self, notebook_obj):
         notebook_path = notebook_obj["path"]
         folder_path = notebook_path
-        for parent in PosixPath(folder_path).parents:
+        for parent in PurePosixPath(folder_path).parents:
             if self.__is_processed_folder(parent):
                 continue
             elif str(parent) == "/":

--- a/databricks_sync/sdk/sync/__init__.py
+++ b/databricks_sync/sdk/sync/__init__.py
@@ -57,7 +57,7 @@ def validate_dict(api_client: ApiClient):
                 log.warning(f"There are no pools to export")
             if object_name == GeneratorCatalog.GLOBAL_INIT_SCRIPT and \
                     GlobalInitScriptsService(api_client).list_global_init_scripts().get("scripts", []) == []:
-                log.warning(f"There are no pools to export")
+                log.warning(f"There are no global init scripts to export")
             if object_name == GeneratorCatalog.SECRET and SecretApi(api_client).list_scopes().get("scopes", []) == []:
                 log.warning(f"There are no secrets to export")
             if object_name == GeneratorCatalog.JOB and JobsApi(api_client).list_jobs().get("jobs", []) == []:


### PR DESCRIPTION
Resolves issues:
#111 - ~Windows path issues~
#112 (~partially fixes the global init scripts being empty but showing up as a dependency in terraform.~ Resolved both issues for cluster policy and global init scripts)

Cluster policies had `${}` phrases which caused terraform errors. 

~The cluster policy definition is base64 encoded which prevents interpolation.~
To resolve this issue `${` is replaced with `$${` before running built in mappings. in terraform `${{` translates to `${` the original intended string of the user.